### PR TITLE
Only try buffer content if present

### DIFF
--- a/src/Microsoft.AspNet.WebApi.MessageHandlers.Compression/ClientCompressionHandler.cs
+++ b/src/Microsoft.AspNet.WebApi.MessageHandlers.Compression/ClientCompressionHandler.cs
@@ -99,8 +99,11 @@
 
             try
             {
-                // Buffer content for further processing
-                await response.Content.LoadIntoBufferAsync();
+                if (response.Content != null)
+                    // Buffer content for further processing
+                    await response.Content.LoadIntoBufferAsync();
+                else
+                    process = false;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNet.WebApi.MessageHandlers.Compression/ServerCompressionHandler.cs
+++ b/src/Microsoft.AspNet.WebApi.MessageHandlers.Compression/ServerCompressionHandler.cs
@@ -101,8 +101,11 @@
 
             try
             {
-                // Buffer content for further processing
-                await response.Content.LoadIntoBufferAsync();
+                if (response.Content != null)
+                    // Buffer content for further processing
+                    await response.Content.LoadIntoBufferAsync();
+                else
+                    process = false;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When enabling breaking on thrown CLR exceptions in VS I hit a NullReferenceException a lot especially when the request is a Delete request with no content. Would be nice if it was possible to not throw these exceptions.