### PR TITLE
README - Owin url fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The above code will skip compression for any request/response that is smaller th
 It is possible to disable compression for a specific endpoint. Just add the `[EnableCompression(false)]` attribute to your endpoint method. (Or the whole controller if you want to disable for all endpoints in it)
 
 #### OWIN Authentication
-When using the OWIN Authentication pipeline, you might encounter errors saying that `Server cannot append header after http headers have been sent`. This is a [bug with OWIN](katanaproject.codeplex.com/discussions/540202), but as of this moment it has not been fixed.  
+When using the OWIN Authentication pipeline, you might encounter errors saying that `Server cannot append header after http headers have been sent`. This is a [bug with OWIN](http://katanaproject.codeplex.com/discussions/540202), but as of this moment it has not been fixed.  
 
 The workaround is to install the [Microsoft.AspNet.WebApi.Extensions.Compression.Server.Owin](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Extensions.Compression.Server.Owin/) package and use the included `OwinServerCompressionHandler` instead of the default `ServerCompressionHandler`. This class contains code to detect whether the headers have been sent already and prevent any attempts at compression.  
 


### PR DESCRIPTION
Without "http://" in front of it, it's trying to navigate to a page within Github