### PR TITLE
copy compressed source directly to destination

### DIFF
--- a/src/Core/Compressors/BaseCompressor.cs
+++ b/src/Core/Compressors/BaseCompressor.cs
@@ -8,7 +8,7 @@ namespace System.Net.Http.Extensions.Compression.Core.Compressors
     /// Base compressor for compressing streams.
     /// </summary>
     /// <remarks>
-    /// Based on the work by: 
+    /// Based on the work by:
     ///     Ben Foster (http://benfoster.io/blog/aspnet-web-api-compression)
     ///     Kiran Challa (http://blogs.msdn.com/b/kiranchalla/archive/2012/09/04/handling-compression-accept-encoding-sample.aspx)
     /// </remarks>
@@ -67,11 +67,7 @@ namespace System.Net.Http.Extensions.Compression.Core.Compressors
 
                 mem.Position = 0;
 
-                var compressed = new byte[mem.Length];
-                await mem.ReadAsync(compressed, 0, compressed.Length);
-
-                var outStream = new MemoryStream(compressed);
-                await outStream.CopyToAsync(destination);
+                await mem.CopyToAsync(destination);
 
                 return mem.Length;
             }


### PR DESCRIPTION
As @phil000 pointed out in #41, there's no need to use the additional buffer; the compressed source buffer can be copied directly to the destination.

_Note:_ this is my very first-ever PR, so I hope I'm doing it right and following appropriate etiquette. Thanks!
